### PR TITLE
Changed CountrySubdivision ISO2 field to correct length

### DIFF
--- a/code/model/CountrySubdivison.php
+++ b/code/model/CountrySubdivison.php
@@ -7,7 +7,7 @@ class CountrySubdivison extends DataObject{
 	static $db = array(
 		'Name' => 'Varchar',
 		'AlternativeNames' => 'Varchar',
-		'ISO2' => 'Varchar(5)', //ISO 3166-2
+		'ISO2' => 'Varchar(6)', //ISO 3166-2
 		'Type' => "Varchar",
 		'Latitude' => 'Decimal(18,12)',
 		'Longitude' => 'Decimal(18,12)'


### PR DESCRIPTION
Hi Jeremy, 
According to Wikipedia (https://en.wikipedia.org/wiki/ISO_3166-2), the ISO code for country subdivisions may be up to 3 characters:
"The second part is a string of up to three alphanumeric characters, which is usually obtained from national sources...".
I've changed the Varchar to 6 characters long.